### PR TITLE
Update methods to return correct type based on the type of value we're retrieving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -83,9 +83,9 @@
       }
     },
     "@capacitor/android": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.1.2.tgz",
-      "integrity": "sha512-WF2E2jWxO3EBl8Y3aTAa8PHwMZGiAl9pdqvJaEUUhbbovXe0UxAuG4n0mfci4ZI6dD8gannQ2peoZ74vJ0Gr3Q==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/android/-/android-3.4.3.tgz",
+      "integrity": "sha512-G/6+mbOde9LMWl5KvA5rB/xEQF05sKrQFMBwo8y3C8pYF+axtcrS0Dgze9rOB7nCjH4NXv/bLw58E9+q8/sQUA==",
       "dev": true
     },
     "@capacitor/core": {
@@ -97,9 +97,9 @@
       }
     },
     "@capacitor/ios": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.1.2.tgz",
-      "integrity": "sha512-y6wnTLK0I/ckTuofzeRkXK0OPw6vAKOj0I6QXwg2DxDdtiHmed6qP/G8cvwNBiFhZE9xfXAulxRYP8D76TPtNQ==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-3.4.3.tgz",
+      "integrity": "sha512-WG6LHzkclYfiF8yBty31j256SD8XmNN1FlOiJUVeu5wz9gM4vw8FpTYIkj2VJoiBnQiB/OWotfnJp2Mp1Rfbtg==",
       "dev": true
     },
     "@firebase/analytics": {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,9 +7,9 @@ export interface FirebaseRemoteConfigPlugin {
   fetch(): Promise<void>;
   activate(): Promise<void>;
   fetchAndActivate(): Promise<void>;
-  getBoolean(options: RCValueOption): Promise<RCReturnData>;
-  getNumber(options: RCValueOption): Promise<RCReturnData>;
-  getString(options: RCValueOption): Promise<RCReturnData>;
+  getBoolean(options: RCValueOption): Promise<RCReturnData<boolean>>;
+  getNumber(options: RCValueOption): Promise<RCReturnData<number>>;
+  getString(options: RCValueOption): Promise<RCReturnData<string>>;
 }
 
 export interface initOptions {
@@ -21,9 +21,9 @@ export interface RCValueOption {
   key: string;
 }
 
-export interface RCReturnData {
+export interface RCReturnData<T = string> {
   key: string;
-  value: string;
+  value: T;
   source: string;
 }
 

--- a/src/web.ts
+++ b/src/web.ts
@@ -70,11 +70,11 @@ export class FirebaseRemoteConfigWeb
     return;
   }
 
-  getBoolean(options: RCValueOption): Promise<RCReturnData> {
+  getBoolean(options: RCValueOption): Promise<RCReturnData<boolean>> {
     return this.getValue(options, "Boolean");
   }
 
-  getNumber(options: RCValueOption): Promise<RCReturnData> {
+  getNumber(options: RCValueOption): Promise<RCReturnData<number>> {
     return this.getValue(options, "Number");
   }
 
@@ -82,10 +82,10 @@ export class FirebaseRemoteConfigWeb
     return this.getValue(options, "String");
   }
 
-  private async getValue(
+  private async getValue<T>(
     options: RCValueOption,
     format: "String" | "Number" | "Boolean" = "String"
-  ): Promise<RCReturnData> {
+  ): Promise<RCReturnData<T>> {
     if (!this.remoteConfigRef)
       throw new Error(
         "Remote config is not initialized. Make sure initialize() is called at first."


### PR DESCRIPTION
This PR fixes an issue where the type definitions would be incorrect when using `getBoolean` or `getNumber` - the `value` returned would always be a string. Now, `RCReturnData` accepts a generic type parameter which can be changed per method.