### PR TITLE
Fix: Initialize never resolve on Android

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
@@ -49,6 +49,7 @@ public class FirebaseRemoteConfig extends Plugin {
       .setFetchTimeoutInSeconds(minFetchTimeInSecs)
       .build();
     this.mFirebaseRemoteConfig.setConfigSettingsAsync(configSettings);
+    call.resolve();
   }
 
   @PluginMethod

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joinflux/firebase-remote-config",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "A native plugin for firebase remote config",
   "homepage": "https://github.com/joinflux/firebase-remote-config",
   "main": "dist/esm/index.js",


### PR DESCRIPTION
The implementation of the `initialize` method is not aligned between iOS and Android.

Checking the plugin definitions, we get:
```typescript
initialize(options?: initOptions): Promise<void>;
fetchAndActivate(): Promise<void>;
```
you would expect to be able to do this
```typescript
await initialize({opts});
await fetchAndActivate();
...
```
Problem is that `initialize` is never resolved on Android and this blocks the web part to continue.
This works fine on iOS
