### PR TITLE
fix: setFetchTimeoutInSeconds not working error.

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
@@ -44,7 +44,7 @@ public class FirebaseRemoteConfig extends Plugin {
 
   @PluginMethod
   public void initialize(PluginCall call) {
-    int minFetchTimeInSecs = call.getInt("minimumFetchIntervalInSeconds", 3600);
+    int minFetchTimeInSecs = call.getInt("minimumFetchInterval", 3600);
     FirebaseRemoteConfigSettings configSettings = new FirebaseRemoteConfigSettings.Builder()
       .setMinimumFetchIntervalInSeconds(minFetchTimeInSecs)
       .build();

--- a/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
+++ b/android/src/main/java/com/getcapacitor/community/firebaserc/FirebaseRemoteConfig.java
@@ -46,7 +46,7 @@ public class FirebaseRemoteConfig extends Plugin {
   public void initialize(PluginCall call) {
     int minFetchTimeInSecs = call.getInt("minimumFetchIntervalInSeconds", 3600);
     FirebaseRemoteConfigSettings configSettings = new FirebaseRemoteConfigSettings.Builder()
-      .setFetchTimeoutInSeconds(minFetchTimeInSecs)
+      .setMinimumFetchIntervalInSeconds(minFetchTimeInSecs)
       .build();
     this.mFirebaseRemoteConfig.setConfigSettingsAsync(configSettings);
     call.resolve();


### PR DESCRIPTION
change `setFetchTimeoutInSeconds` to `setMinimumFetchIntervalInSeconds`


setFetchTimeoutInSeconds is not proper method!


It disables A/B Test with Testing devices.