### PR TITLE
Update firebase-config dependency

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -53,5 +53,5 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
 
-    implementation 'com.google.firebase:firebase-config:19.1.4'
+    implementation 'com.google.firebase:firebase-config:19.2.0'
 }


### PR DESCRIPTION
## Description
Bump minor version of `com.google.firebase:firebase-config` in order to solve Capacitor 4 dependency conflicts.

Most notably, a conflict with `@capacitor/push-notification`, because it needs a new parameter to be passed.

### Conflict with @capacitor/push-notification
When building with @capacitor/push-notification version >= 4, the Android build breaks for incompatible dependency versions during jetifying.
![image](https://user-images.githubusercontent.com/2620476/195416168-2a92c8d1-1c74-4852-a19c-1c288ac676d6.png)

Downgrading `@capacitor/push-notification` to use a compatible version of `firebase-messaging` doesn't work on Capacitor 4 since if needs a new parameter for API >= 31.
```
Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.
Strongly consider using FLAG_IMMUTABLE; only use FLAG_MUTABLE if some functionality depends on the PendingIntent being mutable, e.g. if it needs to be used with inline replies or bubbles.
```